### PR TITLE
Release 0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ Initial release.
 ### Added
 - Created `AocInput` class with initial helper methods
 
-[Unreleased]: https://github.com/pacso/aoc_rb_helpers/compare/v0.0.2...HEAD
+[Unreleased]: https://github.com/pacso/aoc_rb_helpers/compare/v0.0.5...HEAD
+[0.0.5]: https://github.com/pacso/aoc_rb_helpers/compare/v0.0.4...v0.0.5
+[0.0.4]: https://github.com/pacso/aoc_rb_helpers/compare/v0.0.3...v0.0.4
+[0.0.3]: https://github.com/pacso/aoc_rb_helpers/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/pacso/aoc_rb_helpers/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/pacso/aoc_rb_helpers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - No unreleased changes!
 
+## [0.0.5]
+### Added
+- AocInput#process_each_line - Processes each line of the input data using the provided block
+- Grid#includes_coords? - Returns `true` if the provided coordinates exist within the bounds of the grid
+- Grid#beyond_grid? - Returns `true` if the provided coordinates exceed the bounds of the grid
+- Grid#locate(value) - Returns the first coordinates within the grid containing the given value
+- Grid#locate_all(value) - Returns an array of coordinates for any location within the grid containing the given value
+- Grid#each_cell - Iterates over each cell in the grid
+
+### Changed
+- Grid#cell now returns `nil` if the provided coordinates to not exist within the grid
+- Grid#set_cell nwo returns `nil` if the provided coordinates to not exist within the grid
+
+### Fixed
+- Grid#dup previously returned a new `Grid` instance with the same instance of the `@grid` array within it. Now `@grid` is a unique copy.
+
 ## [0.0.4]
 ### Added
 - Grid class for working with two-dimensional arrays of data

--- a/lib/aoc_rb_helpers/aoc_input.rb
+++ b/lib/aoc_rb_helpers/aoc_input.rb
@@ -36,6 +36,26 @@ class AocInput
     self
   end
 
+  # Processes each line of the data using the provided block.
+  #
+  # This method applies the given block to each line in the +@data+ array,
+  # replacing the original +@data+ with the results of the block. The method
+  # returns +self+ to allow method chaining.
+  #
+  # Returns an enumerator if no block is given.
+  #
+  # @yieldparam line [Object, Array<Object>] a single line of the data being processed
+  # @yieldreturn [Object, Array<Object>] the result of processing the line
+  # @return [self] the instance itself, for method chaining
+  # @return [Enumerator] if no block is given
+  def process_each_line
+    return to_enum(__callee__) unless block_given?
+    @data = @data.map do |line|
+      yield line
+    end
+    self
+  end
+
   # Splits each string in the data array into an array of numbers.
   #
   # This method processes +@data+ by splitting each string in the array using the specified delimiter,

--- a/lib/aoc_rb_helpers/grid.rb
+++ b/lib/aoc_rb_helpers/grid.rb
@@ -39,21 +39,32 @@ class Grid
 
   # Returns the value stored at coordinates +(row, column)+ within the grid.
   #
+  # Returns +nil+ if the provided coordinates do not exist within the grid.
+  #
   # Row and column numbers are zero-indexed.
   #
   # @param row [Integer] the row index of the desired cell
   # @param column [Integer] the column index of the desired cell
+  # @return [Object] the value at the given coordinates within the grid
+  # @return [nil] if the given coordinates do not exist within the grid
+  # @see #set_cell
   def cell(row, column)
+    return nil unless includes_coords?(row, column)
     @grid[row][column]
   end
 
   # Updates the cell at coordinates +(row, column)+ with the object provided in +value+; returns the given object.
   #
+  # Returns +nil+ if the provided coordinates do not exist within the grid.
+  #
   # @param row [Integer] the row index of the cell you wish to update
   # @param column [Integer] the column index of the cell you wish to update
   # @param value [Object] the object to assign to the selected grid cell
   # @return [Object] the given +value+
+  # @return [nil] if the provided coordinates do not exist within the grid
+  # @see #cell
   def set_cell(row, column, value)
+    return nil unless includes_coords?(row, column)
     @grid[row][column] = value
   end
 

--- a/lib/aoc_rb_helpers/grid.rb
+++ b/lib/aoc_rb_helpers/grid.rb
@@ -16,6 +16,27 @@ class Grid
     @grid = grid
   end
 
+  # Returns +true+ if the provided coordinates exceed the bounds of the grid; +false+ otherwise.
+  #
+  # @param row [Integer] the row index to test
+  # @param column [Integer] the column index to test
+  # @return [Boolean]
+  # @see #includes_coords?
+  def beyond_grid?(row, column)
+    !includes_coords?(row, column)
+  end
+
+  # Returns +true+ if the provided coordinates exist within the bounds of the grid; +false+ otherwise.
+  #
+  # @param row [Integer] the row index to test
+  # @param column [Integer] the column index to test
+  # @return [Boolean]
+  # @see #beyond_grid?
+  def includes_coords?(row, column)
+    row >= 0 && column >= 0 && row < @grid.length && column < @grid.first.length
+  end
+  alias_method(:within_grid?, :includes_coords?)
+
   # Returns the value stored at coordinates +(row, column)+ within the grid.
   #
   # Row and column numbers are zero-indexed.

--- a/lib/aoc_rb_helpers/grid.rb
+++ b/lib/aoc_rb_helpers/grid.rb
@@ -112,7 +112,7 @@ class Grid
   # Returns a new {Grid} as a copy of self.
   # @return [Grid] a copy of +self+
   def dup
-    Grid.new(@grid)
+    self.class.new(@grid.map { |row| row.map { |cell| cell } })
   end
 
   # Updates +self+ with a rotated grid and returns +self+.

--- a/lib/aoc_rb_helpers/version.rb
+++ b/lib/aoc_rb_helpers/version.rb
@@ -1,3 +1,3 @@
 module AocRbHelpers
-  VERSION = "0.0.4"
+  VERSION = "0.0.5"
 end

--- a/spec/lib/aoc_rb_helpers/aoc_input_spec.rb
+++ b/spec/lib/aoc_rb_helpers/aoc_input_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe AocInput do
     end
   end
 
-  describe "sections" do
+  describe "#sections" do
     let(:input_with_2_sections) do
       <<~EOF
         23|45
@@ -104,6 +104,39 @@ RSpec.describe AocInput do
       sections.each do |section|
         expect(section).to be_an AocInput
       end
+    end
+  end
+
+  describe "#process_each_line" do
+    let(:multi_type_row_input) do
+      <<~EOF
+        abc: 123
+        def: 456
+        ghi: 789
+      EOF
+    end
+    subject(:processed_input) {
+      described_class
+        .new(multi_type_row_input)
+        .multiple_lines
+        .process_each_line do |line|
+        key, value = line.split(": ")
+        [key, value.to_i]
+      end
+    }
+
+    it "returns an instance of AocInput" do
+      expect(processed_input).to be_an AocInput
+    end
+
+    it "modifies @data correctly" do
+      expect(processed_input.data).to eq [["abc", 123], ["def", 456], ["ghi", 789]]
+    end
+
+    it "returns an enumerator if no block is given" do
+      enumerator = described_class.new(multi_type_row_input).multiple_lines.process_each_line
+      expect(enumerator).to be_an Enumerator
+      expect(enumerator.next).to eq "abc: 123"
     end
   end
 

--- a/spec/lib/aoc_rb_helpers/grid_spec.rb
+++ b/spec/lib/aoc_rb_helpers/grid_spec.rb
@@ -188,13 +188,13 @@ RSpec.describe Grid do
     let(:grid) { described_class.new([[0, 1], [2, 3]]) }
 
     it "returns true if the given row and column are in the grid" do
-      [[0,0], [0,1], [1,0], [1,1]].each do |coords|
+      [[0, 0], [0, 1], [1, 0], [1, 1]].each do |coords|
         expect(grid.includes_coords?(*coords)).to be true
       end
     end
 
     it "returns false if the given row and column are not in the grid" do
-      [[-1,0], [0,-1], [0,2], [2,0]].each do |coords|
+      [[-1, 0], [0, -1], [0, 2], [2, 0]].each do |coords|
         expect(grid.includes_coords?(*coords)).to be false
       end
     end
@@ -204,13 +204,13 @@ RSpec.describe Grid do
     let(:grid) { described_class.new([[0, 1], [2, 3]]) }
 
     it "returns false if the given row and column are in the grid" do
-      [[0,0], [0,1], [1,0], [1,1]].each do |coords|
+      [[0, 0], [0, 1], [1, 0], [1, 1]].each do |coords|
         expect(grid.beyond_grid?(*coords)).to be false
       end
     end
 
     it "returns true if the given row and column are not in the grid" do
-      [[-1,0], [0,-1], [0,2], [2,0]].each do |coords|
+      [[-1, 0], [0, -1], [0, 2], [2, 0]].each do |coords|
         expect(grid.beyond_grid?(*coords)).to be true
       end
     end

--- a/spec/lib/aoc_rb_helpers/grid_spec.rb
+++ b/spec/lib/aoc_rb_helpers/grid_spec.rb
@@ -215,4 +215,26 @@ RSpec.describe Grid do
       end
     end
   end
+
+  describe "#dup" do
+    let(:grid) { described_class.new([[0, 1], [2, 3]]) }
+
+    it "returns a new Grid instance" do
+      expect(grid.dup).to be_an_instance_of Grid
+    end
+
+    it "returns a new Grid with a matching @grid" do
+      expect(grid.dup.instance_variable_get(:@grid)).to eq grid.instance_variable_get(:@grid)
+    end
+
+    it "does not create a Grid with the same instance of @grid" do
+      expect(grid.dup.instance_variable_get(:@grid)).not_to be grid.instance_variable_get(:@grid)
+    end
+
+    it "isolates changes in the new grid from the original" do
+      other = grid.dup
+      expect { other.set_cell(0, 0, "9") }.not_to change { grid.cell(0, 0) }.from(0)
+      expect(other.cell(0, 0)).to eq "9"
+    end
+  end
 end

--- a/spec/lib/aoc_rb_helpers/grid_spec.rb
+++ b/spec/lib/aoc_rb_helpers/grid_spec.rb
@@ -169,4 +169,36 @@ RSpec.describe Grid do
       expect(grid).to eq Grid.new([[0, 1], [2, 3]])
     end
   end
+
+  describe "#includes_coords?(row, column)" do
+    let(:grid) { described_class.new([[0, 1], [2, 3]]) }
+
+    it "returns true if the given row and column are in the grid" do
+      [[0,0], [0,1], [1,0], [1,1]].each do |coords|
+        expect(grid.includes_coords?(*coords)).to be true
+      end
+    end
+
+    it "returns false if the given row and column are not in the grid" do
+      [[-1,0], [0,-1], [0,2], [2,0]].each do |coords|
+        expect(grid.includes_coords?(*coords)).to be false
+      end
+    end
+  end
+
+  describe "#beyond_grid?(row, column)" do
+    let(:grid) { described_class.new([[0, 1], [2, 3]]) }
+
+    it "returns false if the given row and column are in the grid" do
+      [[0,0], [0,1], [1,0], [1,1]].each do |coords|
+        expect(grid.beyond_grid?(*coords)).to be false
+      end
+    end
+
+    it "returns true if the given row and column are not in the grid" do
+      [[-1,0], [0,-1], [0,2], [2,0]].each do |coords|
+        expect(grid.beyond_grid?(*coords)).to be true
+      end
+    end
+  end
 end

--- a/spec/lib/aoc_rb_helpers/grid_spec.rb
+++ b/spec/lib/aoc_rb_helpers/grid_spec.rb
@@ -237,4 +237,73 @@ RSpec.describe Grid do
       expect(other.cell(0, 0)).to eq "9"
     end
   end
+
+  describe "#locate" do
+    let(:grid) { described_class.new([%w[a b], %w[c d]]) }
+
+    it "returns the coordinates of the given value" do
+      expect(grid.locate("a")).to eq [0, 0]
+      expect(grid.locate("b")).to eq [0, 1]
+      expect(grid.locate("c")).to eq [1, 0]
+      expect(grid.locate("d")).to eq [1, 1]
+    end
+
+    it "returns nil if the given value is not in the grid" do
+      expect(grid.locate("missing")).to be_nil
+    end
+
+    context "with a grid contining duplicate values" do
+      let(:grid) { described_class.new([%w[a b], %w[b a]]) }
+
+      it "returns the first coordinate of the given value, searching from the top-left by row" do
+        expect(grid.locate("a")).to eq [0, 0]
+        expect(grid.locate("b")).to eq [0, 1]
+      end
+    end
+  end
+
+  describe "#locate_all" do
+    let(:grid) { described_class.new([%w[a b c a], %w[c d e b], %w[f a g h]]) }
+
+    it "returns all coordinates of the given value" do
+      expect(grid.locate_all("a")).to eq [[0, 0], [0, 3], [2, 1]]
+    end
+
+    it "returns an empty array if the given value is not in the grid" do
+      expect(grid.locate_all("missing")).to eq []
+    end
+  end
+
+  describe "#each_cell" do
+    let(:grid) { described_class.new([%w[a b], %w[c d]]) }
+
+    it "returns an enumerator when no block is given" do
+      e = grid.each_cell
+      expect(e).to be_an Enumerator
+      expect(e.next).to eq [[0, 0], "a"]
+    end
+
+    it "allows the grid to be modified during iteration" do
+      grid.each_cell { |coords, value| grid.set_cell(*coords, value * 2) }
+      expect(grid.cell(0, 0)).to eq "aa"
+    end
+
+    it "returns self when given a block" do
+      expect(grid.each_cell { |_, value| value * 2 }).to eq grid
+    end
+
+    it "yields the coordinates and values of each cell in the grid" do
+      expected_values = [
+        [[0, 0], "a"],
+        [[0, 1], "b"],
+        [[1, 0], "c"],
+        [[1, 1], "d"],
+      ]
+      returned_values = []
+      grid.each_cell do |coords, value|
+        returned_values << [coords, value]
+      end
+      expect(returned_values).to eq expected_values
+    end
+  end
 end

--- a/spec/lib/aoc_rb_helpers/grid_spec.rb
+++ b/spec/lib/aoc_rb_helpers/grid_spec.rb
@@ -21,17 +21,31 @@ RSpec.describe Grid do
   end
 
   describe "#cell(y, x)" do
+    let(:grid) { described_class.from_input(input_text) }
+
     it "returns the cell at the given coordinates" do
-      grid = described_class.from_input(input_text)
       expect(grid.cell(0, 0)).to eq "a"
+    end
+
+    it "returns nil if the coords are out of bounds" do
+      expect(grid.cell(-1, -1)).to be_nil
     end
   end
 
   describe "#set_cell(y, x, value)" do
+    let(:grid) { described_class.from_input(input_text) }
+
     it "sets the cell at the given coordinates" do
-      grid = described_class.from_input(input_text)
-      grid.set_cell(0, 0, "z")
-      expect(grid.cell(0, 0)).to eq "z"
+      expect { grid.set_cell(0, 0, "z") }
+        .to change { grid.cell(0, 0) }.from("a").to("z")
+    end
+
+    it "returns nil if the coordinates are out of bounds" do
+      expect(grid.set_cell(-1, 0, "z")).to be_nil
+    end
+
+    it "does not modify the grid if the coordinates are out of bounds" do
+      expect { grid.set_cell(-1, 0, "z") }.not_to change { grid.instance_variable_get("@grid") }
     end
   end
 

--- a/spec/lib/aoc_rb_helpers_spec.rb
+++ b/spec/lib/aoc_rb_helpers_spec.rb
@@ -4,6 +4,6 @@ require 'spec_helper'
 
 RSpec.describe AocRbHelpers do
   it "has the expected version number" do
-    expect(AocRbHelpers::VERSION).to eq "0.0.4"
+    expect(AocRbHelpers::VERSION).to eq "0.0.5"
   end
 end


### PR DESCRIPTION
### Added
- AocInput#process_each_line - Processes each line of the input data using the provided block
- Grid#includes_coords? - Returns `true` if the provided coordinates exist within the bounds of the grid
- Grid#beyond_grid? - Returns `true` if the provided coordinates exceed the bounds of the grid
- Grid#locate(value) - Returns the first coordinates within the grid containing the given value
- Grid#locate_all(value) - Returns an array of coordinates for any location within the grid containing the given value
- Grid#each_cell - Iterates over each cell in the grid

### Changed
- Grid#cell now returns `nil` if the provided coordinates to not exist within the grid
- Grid#set_cell nwo returns `nil` if the provided coordinates to not exist within the grid

### Fixed
- Grid#dup previously returned a new `Grid` instance with the same instance of the `@grid` array within it. Now `@grid` is a unique copy.
